### PR TITLE
feat: add health_check url for k8s probe

### DIFF
--- a/cmd/mcp-gateway/main.go
+++ b/cmd/mcp-gateway/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -241,6 +242,13 @@ func run() {
 	}
 
 	router := gin.Default()
+	// add health_check url for k8s readiness probe
+	router.GET("/health_check", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status":  "ok",
+			"message": "Health check passed.",
+		})
+	})
 	if err := srv.RegisterRoutes(router, mcpCfg); err != nil {
 		logger.Fatal("failed to register routes",
 			zap.Error(err))

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -78,7 +78,7 @@ func (s *Server) RegisterRoutes(router *gin.Engine, cfg *config.MCPConfig) error
 	s.state = newState
 
 	// Register all routes under root path
-	router.Any("/*path", s.handleRoot)
+	router.NoRoute(s.handleRoot)
 
 	return nil
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a health_check endpoint for Kubernetes probes and refine default routing by using NoRoute instead of Any.

New Features:
- Add /health_check endpoint for Kubernetes readiness probe

Enhancements:
- Replace wildcard Any route with NoRoute for fallback handler