### PR TITLE
refactor: Use time.Duration for timeout instead of int.

### DIFF
--- a/configs/mcp-gateway.yaml
+++ b/configs/mcp-gateway.yaml
@@ -32,7 +32,7 @@ storage:
   api:
     url: "${GATEWAY_STORAGE_API_URL:}"
     configJSONPath: "${GATEWAY_STORAGE_API_CONFIG_JSON_PATH:}"
-    timeout: "${GATEWAY_STORAGE_API_TIMEOUT:}"
+    timeout: "${GATEWAY_STORAGE_API_TIMEOUT:30s}"
 
 # Notifier configuration
 notifier:

--- a/internal/common/config/storage.go
+++ b/internal/common/config/storage.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 type (
 	StorageConfig struct {
 		Type     string            `yaml:"type"`     // disk or db
@@ -13,8 +15,8 @@ type (
 	}
 
 	APIStorageConfig struct {
-		Url            string `yaml:"url"`            // http url for api
-		ConfigJSONPath string `yaml:"configJSONPath"` // configJSONPath for config in http response
-		Timeout        int    `yaml:"timeout"`        // timeout(seconds) for http request
+		Url            string        `yaml:"url"`            // http url for api
+		ConfigJSONPath string        `yaml:"configJSONPath"` // configJSONPath for config in http response
+		Timeout        time.Duration `yaml:"timeout"`        // timeout for http request
 	}
 )

--- a/internal/mcp/storage/api.go
+++ b/internal/mcp/storage/api.go
@@ -21,13 +21,13 @@ type APIStore struct {
 	url    string
 	// read config from response(json body) using gjson
 	configJSONPath string
-	timeout        int
+	timeout        time.Duration
 }
 
 var _ Store = (*APIStore)(nil)
 
 // NewAPIStore creates a new api-based store
-func NewAPIStore(logger *zap.Logger, url string, configJSONPath string, timeout int) (*APIStore, error) {
+func NewAPIStore(logger *zap.Logger, url string, configJSONPath string, timeout time.Duration) (*APIStore, error) {
 	logger = logger.Named("mcp.store")
 
 	logger.Info("Using configuration url", zap.String("path", url))
@@ -88,7 +88,7 @@ func (s *APIStore) Delete(_ context.Context, name string) error {
 
 func (s *APIStore) request() (string, error) {
 	client := &http.Client{
-		Timeout: time.Duration(s.timeout) * time.Second,
+		Timeout: s.timeout,
 	}
 	resp, err := client.Get(s.url)
 	if err != nil {


### PR DESCRIPTION
## Summary by Sourcery

Refactor the API storage timeout handling across configuration, code, and default values to use Go’s time.Duration instead of an integer value.

Enhancements:
- Use time.Duration for timeout in APIStorageConfig and APIStore instead of raw int
- Update NewAPIStore signature and HTTP client setup to accept the duration type directly
- Adjust the default timeout in mcp-gateway.yaml to a duration string (30s) to match the new type