### PR TITLE
Feat add context data with cookies and querystring

### DIFF
--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -42,6 +42,20 @@ func prepareTemplateContext(args map[string]any, request *http.Request, serverCf
 		}
 	}
 
+	// Process request querystring
+	for k, v := range request.URL.Query() {
+		if len(v) > 0 {
+			tmplCtx.Request.Query[k] = v[0]
+		}
+	}
+
+	// Process request cookies
+	for _, cookie := range request.Cookies() {
+		if cookie.Name != "" {
+			tmplCtx.Request.Cookies[cookie.Name] = cookie.Value
+		}
+	}
+
 	// Only process server config templates if serverCfg is provided
 	if serverCfg != nil {
 		// Process server config templates

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -14,6 +14,7 @@ type (
 	RequestWrapper struct {
 		Headers map[string]string `json:"headers"`
 		Query   map[string]string `json:"query"`
+		Cookies map[string]string `json:"cookies"`
 		Path    map[string]string `json:"path"`
 		Body    map[string]any    `json:"body"`
 	}
@@ -31,6 +32,7 @@ func NewContext() *Context {
 		Request: RequestWrapper{
 			Headers: make(map[string]string),
 			Query:   make(map[string]string),
+			Cookies: make(map[string]string),
 			Path:    make(map[string]string),
 			Body:    make(map[string]any),
 		},


### PR DESCRIPTION
Add querystring and cookies in `templateContext`, the values are from origin request.