### PR TITLE
Feat merge the headers/cookies/querystring info in the first and later request

### DIFF
--- a/internal/core/mcpproxy/sse.go
+++ b/internal/core/mcpproxy/sse.go
@@ -10,13 +10,14 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
+	"github.com/mcp-ecosystem/mcp-gateway/internal/mcp/session"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/template"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/mcp"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/version"
 )
 
 // FetchSSEToolList fetches the list of available tools from an SSE backend
-func FetchSSEToolList(ctx context.Context, mcpProxyCfg config.MCPServerConfig) ([]mcp.ToolSchema, error) {
+func FetchSSEToolList(ctx context.Context, _ session.Connection, mcpProxyCfg config.MCPServerConfig) ([]mcp.ToolSchema, error) {
 	// Create SSE transport
 	sseTransport, err := transport.NewSSE(mcpProxyCfg.URL)
 	if err != nil {
@@ -95,7 +96,7 @@ func FetchSSEToolList(ctx context.Context, mcpProxyCfg config.MCPServerConfig) (
 }
 
 // InvokeSSETool handles tool invocation for SSE MCP protocol
-func InvokeSSETool(c *gin.Context, mcpProxyCfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
+func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	// Convert arguments to map[string]any
 	var args map[string]any
 	if err := json.Unmarshal(params.Arguments, &args); err != nil {
@@ -103,7 +104,7 @@ func InvokeSSETool(c *gin.Context, mcpProxyCfg config.MCPServerConfig, params mc
 	}
 
 	// Prepare template context for environment variables
-	tmplCtx, err := template.PrepareTemplateContext(args, c.Request, nil)
+	tmplCtx, err := template.PrepareTemplateContext(conn.Meta().Request, args, c.Request, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare template context: %w", err)
 	}

--- a/internal/core/mcpproxy/streamable.go
+++ b/internal/core/mcpproxy/streamable.go
@@ -10,13 +10,14 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
+	"github.com/mcp-ecosystem/mcp-gateway/internal/mcp/session"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/template"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/mcp"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/version"
 )
 
 // FetchStreamableToolList fetches the list of available tools from a Streamable HTTP backend
-func FetchStreamableToolList(ctx context.Context, mcpProxyCfg config.MCPServerConfig) ([]mcp.ToolSchema, error) {
+func FetchStreamableToolList(ctx context.Context, _ session.Connection, mcpProxyCfg config.MCPServerConfig) ([]mcp.ToolSchema, error) {
 	// Create Streamable HTTP transport
 	streamableTransport, err := transport.NewStreamableHTTP(mcpProxyCfg.URL)
 	if err != nil {
@@ -95,7 +96,7 @@ func FetchStreamableToolList(ctx context.Context, mcpProxyCfg config.MCPServerCo
 }
 
 // InvokeStreamableTool handles tool invocation for Streamable HTTP MCP protocol
-func InvokeStreamableTool(ctx *gin.Context, mcpProxyCfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
+func InvokeStreamableTool(ctx *gin.Context, conn session.Connection, mcpProxyCfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	// Convert arguments to map[string]any
 	var args map[string]any
 	if err := json.Unmarshal(params.Arguments, &args); err != nil {
@@ -103,7 +104,7 @@ func InvokeStreamableTool(ctx *gin.Context, mcpProxyCfg config.MCPServerConfig, 
 	}
 
 	// Prepare template context for environment variables
-	tmplCtx, err := template.PrepareTemplateContext(args, ctx.Request, nil)
+	tmplCtx, err := template.PrepareTemplateContext(conn.Meta().Request, args, ctx.Request, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare template context: %w", err)
 	}

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -31,12 +31,31 @@ func (s *Server) handleSSE(c *gin.Context) {
 		prefix = "/"
 	}
 
+	requestInfo := &session.RequestInfo{
+		Headers: make(map[string]string),
+		Query:   make(map[string]string),
+		Cookies: make(map[string]string),
+	}
+	// Process request headers
+	for k, v := range c.Request.Header {
+		requestInfo.Headers[k] = v[0]
+	}
+	// Process request querystring
+	for k, v := range c.Request.URL.Query() {
+		requestInfo.Query[k] = v[0]
+	}
+	// Process request cookies
+	for _, cookie := range c.Request.Cookies() {
+		requestInfo.Cookies[cookie.Name] = cookie.Value
+	}
+
 	sessionID := uuid.New().String()
 	meta := &session.Meta{
 		ID:        sessionID,
 		CreatedAt: time.Now(),
 		Prefix:    prefix,
 		Type:      "sse",
+		Request:   requestInfo,
 		Extra:     nil,
 	}
 
@@ -197,7 +216,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			tools, err = mcpproxy.FetchStdioToolList(c.Request.Context(), mcpProxyCfg)
+			tools, err = mcpproxy.FetchStdioToolList(c.Request.Context(), conn, mcpProxyCfg)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -209,7 +228,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			tools, err = mcpproxy.FetchSSEToolList(c.Request.Context(), mcpProxyCfg)
+			tools, err = mcpproxy.FetchSSEToolList(c.Request.Context(), conn, mcpProxyCfg)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -221,7 +240,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			tools, err = mcpproxy.FetchStreamableToolList(c.Request.Context(), mcpProxyCfg)
+			tools, err = mcpproxy.FetchStreamableToolList(c.Request.Context(), conn, mcpProxyCfg)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -272,7 +291,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 				return
 			}
-			result, err = mcpproxy.InvokeStdioTool(c, mcpProxyCfg, params)
+			result, err = mcpproxy.InvokeStdioTool(c, conn, mcpProxyCfg, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -284,7 +303,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 				return
 			}
-			result, err = mcpproxy.InvokeSSETool(c, mcpProxyCfg, params)
+			result, err = mcpproxy.InvokeSSETool(c, conn, mcpProxyCfg, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -296,7 +315,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 				return
 			}
-			result, err = mcpproxy.InvokeStreamableTool(c, mcpProxyCfg, params)
+			result, err = mcpproxy.InvokeStreamableTool(c, conn, mcpProxyCfg, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -38,15 +38,21 @@ func (s *Server) handleSSE(c *gin.Context) {
 	}
 	// Process request headers
 	for k, v := range c.Request.Header {
-		requestInfo.Headers[k] = v[0]
+		if len(v) > 0 {
+			requestInfo.Headers[k] = v[0]
+		}
 	}
 	// Process request querystring
 	for k, v := range c.Request.URL.Query() {
-		requestInfo.Query[k] = v[0]
+		if len(v) > 0 {
+			requestInfo.Query[k] = v[0]
+		}
 	}
 	// Process request cookies
 	for _, cookie := range c.Request.Cookies() {
-		requestInfo.Cookies[cookie.Name] = cookie.Value
+		if cookie != nil && cookie.Name != "" {
+			requestInfo.Cookies[cookie.Name] = cookie.Value
+		}
 	}
 
 	sessionID := uuid.New().String()

--- a/internal/core/streamable.go
+++ b/internal/core/streamable.go
@@ -231,7 +231,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = mcpproxy.FetchStdioToolList(c.Request.Context(), mcpProxyCfg)
+			tools, err = mcpproxy.FetchStdioToolList(c.Request.Context(), conn, mcpProxyCfg)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -243,7 +243,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = mcpproxy.FetchSSEToolList(c.Request.Context(), mcpProxyCfg)
+			tools, err = mcpproxy.FetchSSEToolList(c.Request.Context(), conn, mcpProxyCfg)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -255,7 +255,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = mcpproxy.FetchStreamableToolList(c.Request.Context(), mcpProxyCfg)
+			tools, err = mcpproxy.FetchStreamableToolList(c.Request.Context(), conn, mcpProxyCfg)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -312,7 +312,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 			}
 
 			// Execute the tool
-			result, err = s.executeHTTPTool(tool, args, c.Request, serverCfg.Config)
+			result, err = s.executeHTTPTool(conn, tool, args, c.Request, serverCfg.Config)
 			if err != nil {
 				s.logger.Error("failed to execute tool", zap.Error(err))
 				s.sendToolExecutionError(c, conn, req, err, false)
@@ -325,7 +325,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 				return
 			}
-			result, err = mcpproxy.InvokeStdioTool(c, mcpProxyCfg, params)
+			result, err = mcpproxy.InvokeStdioTool(c, conn, mcpProxyCfg, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -337,7 +337,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 				return
 			}
-			result, err = mcpproxy.InvokeSSETool(c, mcpProxyCfg, params)
+			result, err = mcpproxy.InvokeSSETool(c, conn, mcpProxyCfg, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -349,7 +349,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 				return
 			}
-			result, err = mcpproxy.InvokeStreamableTool(c, mcpProxyCfg, params)
+			result, err = mcpproxy.InvokeStreamableTool(c, conn, mcpProxyCfg, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, false)
 				return

--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -100,9 +100,9 @@ func preprocessResponseData(data map[string]any) map[string]any {
 }
 
 // executeHTTPTool executes a tool with the given arguments
-func (s *Server) executeHTTPTool(tool *config.ToolConfig, args map[string]any, request *http.Request, serverCfg map[string]string) (*mcp.CallToolResult, error) {
+func (s *Server) executeHTTPTool(conn session.Connection, tool *config.ToolConfig, args map[string]any, request *http.Request, serverCfg map[string]string) (*mcp.CallToolResult, error) {
 	// Prepare template context
-	tmplCtx, err := template.PrepareTemplateContext(args, request, serverCfg)
+	tmplCtx, err := template.PrepareTemplateContext(conn.Meta().Request, args, request, serverCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (s *Server) invokeHTTPTool(c *gin.Context, req mcp.JSONRPCRequest, conn ses
 	}
 
 	// Execute the tool
-	result, err := s.executeHTTPTool(tool, args, c.Request, serverCfg.Config)
+	result, err := s.executeHTTPTool(conn, tool, args, c.Request, serverCfg.Config)
 	if err != nil {
 		s.sendToolExecutionError(c, conn, req, err, true)
 		return nil

--- a/internal/mcp/session/session.go
+++ b/internal/mcp/session/session.go
@@ -11,13 +11,21 @@ type Message struct {
 	Data  []byte // Payload
 }
 
+// RequestInfo holds information about the request that created the session.
+type RequestInfo struct {
+	Headers map[string]string `json:"headers"`
+	Query   map[string]string `json:"query"`
+	Cookies map[string]string `json:"cookies"`
+}
+
 // Meta holds immutable metadata about a session.
 type Meta struct {
-	ID        string    `json:"id"`         // Unique session ID
-	CreatedAt time.Time `json:"created_at"` // Timestamp of session creation
-	Prefix    string    `json:"prefix"`     // Optional namespace or application prefix
-	Type      string    `json:"type"`       // Connection type, e.g., "sse", "streamable"
-	Extra     []byte    `json:"extra"`      // Optional serialized extra data
+	ID        string       `json:"id"`         // Unique session ID
+	CreatedAt time.Time    `json:"created_at"` // Timestamp of session creation
+	Prefix    string       `json:"prefix"`     // Optional namespace or application prefix
+	Type      string       `json:"type"`       // Connection type, e.g., "sse", "streamable"
+	Request   *RequestInfo `json:"request"`    // Request information
+	Extra     []byte       `json:"extra"`      // Optional serialized extra data
 }
 
 // Connection represents an active session connection capable of sending messages.


### PR DESCRIPTION
When execute `tools/call`, it lost the first request metadata include headers/cookies/querystring. In this PR, we merge the metadata in requests, and use the latest request metadata to ovrride the first request.

## Summary by Sourcery

Capture and propagate HTTP request metadata across sessions and tool invocations to ensure headers, query parameters, and cookies persist and merge correctly.

New Features:
- Store initial request headers, query parameters, and cookies in a new RequestInfo attached to session metadata.
- Merge stored metadata with each subsequent request, overriding values with the latest request data.

Enhancements:
- Extend PrepareTemplateContext to accept RequestInfo and merge initial and current request metadata before rendering.
- Refactor mcpproxy fetch and invoke functions and core server handlers to pass session.Connection and propagate RequestInfo through tool execution APIs.