### PR TITLE
Feat/add mcp server policy

### DIFF
--- a/cmd/mcp-gateway/main.go
+++ b/cmd/mcp-gateway/main.go
@@ -114,7 +114,7 @@ var (
 		},
 	}
 	rootCmd = &cobra.Command{
-		Use:   "mcp-gateway",
+		Use:   cnst.CommandName,
 		Short: "MCP Gateway service",
 		Long:  `MCP Gateway is a service that provides API gateway functionality for MCP ecosystem`,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/mcp-gateway/main.go
+++ b/cmd/mcp-gateway/main.go
@@ -162,7 +162,7 @@ func handleReload(ctx context.Context, logger *zap.Logger, store storage.Store, 
 	}
 
 	// Update server configuration in place
-	if err := srv.UpdateConfig(newMCPCfgs); err != nil {
+	if err := srv.UpdateConfig(ctx, newMCPCfgs); err != nil {
 		logger.Error("failed to update server configuration",
 			zap.Error(err))
 		return
@@ -171,7 +171,7 @@ func handleReload(ctx context.Context, logger *zap.Logger, store storage.Store, 
 	logger.Info("Configuration reloaded successfully")
 }
 
-func handleMerge(_ context.Context, logger *zap.Logger, srv *core.Server, mcpConfig *config.MCPConfig) {
+func handleMerge(ctx context.Context, logger *zap.Logger, srv *core.Server, mcpConfig *config.MCPConfig) {
 	logger.Info("Merging MCP configuration")
 	// Validate configurations before merging
 	if err := config.ValidateMCPConfig(mcpConfig); err != nil {
@@ -187,7 +187,7 @@ func handleMerge(_ context.Context, logger *zap.Logger, srv *core.Server, mcpCon
 	}
 
 	// Update server configuration in place
-	if err := srv.MergeConfig(mcpConfig); err != nil {
+	if err := srv.MergeConfig(ctx, mcpConfig); err != nil {
 		logger.Error("failed to merge server configuration",
 			zap.Error(err))
 		return
@@ -274,7 +274,7 @@ func run() {
 			"message": "Health check passed.",
 		})
 	})
-	if err := srv.RegisterRoutes(router, mcpCfgs); err != nil {
+	if err := srv.RegisterRoutes(ctx, router, mcpCfgs); err != nil {
 		logger.Fatal("failed to register routes",
 			zap.Error(err))
 	}

--- a/configs/proxy-mcp-exp.yaml
+++ b/configs/proxy-mcp-exp.yaml
@@ -59,12 +59,15 @@ mcpServers:
       - "-y"
       - "@amap/amap-maps-mcp-server"
     env:
-      AMAP_MAPS_API_KEY: "{{.Request.Headers.Apikey}}"
+      AMAP_MAPS_API_KEY: "{{ env AMAP_MAPS_API_KEY }}"
+    policy: "onStart"
 
   - type: "sse"
     name: "mock-user-sse"
     url: "http://localhost:3000/mcp/user/sse"
+    policy: "onDemand"
 
   - type: "streamable-http"  # unimplemented for now
     name: "mock-user-mcp"
     url: "http://localhost:3000/mcp/user/mcp"
+    policy: "onDemand"

--- a/internal/common/cnst/app.go
+++ b/internal/common/cnst/app.go
@@ -1,0 +1,6 @@
+package cnst
+
+const (
+	AppName     = "mcp-gateway"
+	CommandName = "mcp-gateway"
+)

--- a/internal/common/cnst/policy.go
+++ b/internal/common/cnst/policy.go
@@ -1,0 +1,11 @@
+package cnst
+
+// MCPStartupPolicy represents the startup policy for MCP servers
+type MCPStartupPolicy string
+
+const (
+	// PolicyOnStart represents the policy to connect on server start
+	PolicyOnStart MCPStartupPolicy = "onStart"
+	// PolicyOnDemand represents the policy to connect when needed
+	PolicyOnDemand MCPStartupPolicy = "onDemand"
+)

--- a/internal/common/config/mcp.go
+++ b/internal/common/config/mcp.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ifuryst/lol"
 
+	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/mcp"
 )
 
@@ -64,12 +65,13 @@ type (
 	}
 
 	MCPServerConfig struct {
-		Type    string            `json:"type" yaml:"type"`                           // sse, stdio and streamable-http
-		Name    string            `json:"name" yaml:"name"`                           // server name
-		Command string            `json:"command,omitempty" yaml:"command,omitempty"` // for stdio
-		Args    []string          `json:"args,omitempty" yaml:"args,omitempty"`       // for stdio
-		Env     map[string]string `json:"env,omitempty" yaml:"env,omitempty"`         // for stdio
-		URL     string            `json:"url,omitempty" yaml:"url,omitempty"`         // for sse and streamable-http
+		Type    string                `json:"type" yaml:"type"`                           // sse, stdio and streamable-http
+		Name    string                `json:"name" yaml:"name"`                           // server name
+		Command string                `json:"command,omitempty" yaml:"command,omitempty"` // for stdio
+		Args    []string              `json:"args,omitempty" yaml:"args,omitempty"`       // for stdio
+		Env     map[string]string     `json:"env,omitempty" yaml:"env,omitempty"`         // for stdio
+		URL     string                `json:"url,omitempty" yaml:"url,omitempty"`         // for sse and streamable-http
+		Policy  cnst.MCPStartupPolicy `json:"policy" yaml:"policy"`                       // onStart or onDemand
 	}
 
 	ArgConfig struct {

--- a/internal/core/mcpproxy/sse.go
+++ b/internal/core/mcpproxy/sse.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gin-gonic/gin"
+	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
+
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
-	"github.com/mcp-ecosystem/mcp-gateway/internal/mcp/session"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/template"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/mcp"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/version"
@@ -25,7 +25,7 @@ type SSETransport struct {
 var _ Transport = (*SSETransport)(nil)
 
 func (t *SSETransport) Start(ctx context.Context, tmplCtx *template.Context) error {
-	if t.IsStarted() {
+	if t.IsRunning() {
 		return nil
 	}
 
@@ -47,7 +47,7 @@ func (t *SSETransport) Start(ctx context.Context, tmplCtx *template.Context) err
 	initRequest := mcpgo.InitializeRequest{}
 	initRequest.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
 	initRequest.Params.ClientInfo = mcpgo.Implementation{
-		Name:    "mcp-gateway",
+		Name:    cnst.AppName,
 		Version: version.Get(),
 	}
 
@@ -62,7 +62,7 @@ func (t *SSETransport) Start(ctx context.Context, tmplCtx *template.Context) err
 }
 
 func (t *SSETransport) Stop(_ context.Context) error {
-	if !t.IsStarted() {
+	if !t.IsRunning() {
 		return nil
 	}
 
@@ -73,13 +73,12 @@ func (t *SSETransport) Stop(_ context.Context) error {
 	return nil
 }
 
-func (t *SSETransport) IsStarted() bool {
+func (t *SSETransport) IsRunning() bool {
 	return t.client != nil
 }
 
-// FetchToolList implements Transport.FetchToolList
-func (t *SSETransport) FetchToolList(ctx context.Context, _ session.Connection) ([]mcp.ToolSchema, error) {
-	if !t.IsStarted() {
+func (t *SSETransport) FetchTools(ctx context.Context) ([]mcp.ToolSchema, error) {
+	if !t.IsRunning() {
 		if err := t.Start(ctx, nil); err != nil {
 			return nil, err
 		}
@@ -134,10 +133,9 @@ func (t *SSETransport) FetchToolList(ctx context.Context, _ session.Connection) 
 	return tools, nil
 }
 
-// InvokeTool implements Transport.InvokeTool
-func (t *SSETransport) InvokeTool(c *gin.Context, conn session.Connection, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
-	if !t.IsStarted() {
-		if err := t.Start(c.Request.Context(), nil); err != nil {
+func (t *SSETransport) CallTool(ctx context.Context, params mcp.CallToolParams, req *template.RequestWrapper) (*mcp.CallToolResult, error) {
+	if !t.IsRunning() {
+		if err := t.Start(ctx, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -149,7 +147,7 @@ func (t *SSETransport) InvokeTool(c *gin.Context, conn session.Connection, param
 	}
 
 	// Prepare template context for environment variables
-	tmplCtx, err := template.PrepareTemplateContext(conn.Meta().Request, args, c.Request, nil)
+	tmplCtx, err := template.AssembleTemplateContext(req, args, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare template context: %w", err)
 	}
@@ -175,50 +173,10 @@ func (t *SSETransport) InvokeTool(c *gin.Context, conn session.Connection, param
 	callRequest.Params.Name = params.Name
 	callRequest.Params.Arguments = toolCallRequestParams
 
-	mcpgoResult, err := t.client.CallTool(c.Request.Context(), callRequest)
+	mcpgoResult, err := t.client.CallTool(ctx, callRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}
 
-	// Convert mcp-go result to local mcp format
-	result := &mcp.CallToolResult{
-		IsError: mcpgoResult.IsError,
-	}
-
-	// Process content items
-	if len(mcpgoResult.Content) > 0 {
-		var validContents []mcp.Content
-
-		for _, content := range mcpgoResult.Content {
-			// Skip null content
-			if content == nil {
-				continue
-			}
-
-			// Convert content to local format
-			switch c := content.(type) {
-			case *mcpgo.TextContent:
-				validContents = append(validContents, &mcp.TextContent{
-					Type: "text",
-					Text: c.Text,
-				})
-			case *mcpgo.ImageContent:
-				validContents = append(validContents, &mcp.ImageContent{
-					Type:     "image",
-					Data:     c.Data,
-					MimeType: c.MIMEType,
-				})
-			case *mcpgo.AudioContent:
-				validContents = append(validContents, &mcp.AudioContent{
-					Type:     "audio",
-					Data:     c.Data,
-					MimeType: c.MIMEType,
-				})
-			}
-		}
-
-		result.Content = validContents
-	}
-
-	return result, nil
+	return convertMCPGoResult(mcpgoResult), nil
 }

--- a/internal/core/mcpproxy/streamable.go
+++ b/internal/core/mcpproxy/streamable.go
@@ -19,17 +19,18 @@ import (
 // StreamableTransport implements Transport using Streamable HTTP
 type StreamableTransport struct {
 	client *client.Client
+	cfg    config.MCPServerConfig
 }
 
 var _ Transport = (*StreamableTransport)(nil)
 
-func (t *StreamableTransport) Start(ctx context.Context, cfg config.MCPServerConfig) error {
+func (t *StreamableTransport) Start(ctx context.Context, tmplCtx *template.Context) error {
 	if t.IsStarted() {
 		return nil
 	}
 
 	// Create streamable transport
-	streamableTransport, err := transport.NewStreamableHTTP(cfg.URL)
+	streamableTransport, err := transport.NewStreamableHTTP(t.cfg.URL)
 	if err != nil {
 		return fmt.Errorf("failed to create Streamable HTTP transport: %w", err)
 	}
@@ -77,9 +78,9 @@ func (t *StreamableTransport) IsStarted() bool {
 }
 
 // FetchToolList implements Transport.FetchToolList
-func (t *StreamableTransport) FetchToolList(ctx context.Context, _ session.Connection, mcpProxyCfg config.MCPServerConfig) ([]mcp.ToolSchema, error) {
+func (t *StreamableTransport) FetchToolList(ctx context.Context, _ session.Connection) ([]mcp.ToolSchema, error) {
 	if !t.IsStarted() {
-		if err := t.Start(ctx, mcpProxyCfg); err != nil {
+		if err := t.Start(ctx, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -134,9 +135,9 @@ func (t *StreamableTransport) FetchToolList(ctx context.Context, _ session.Conne
 }
 
 // InvokeTool implements Transport.InvokeTool
-func (t *StreamableTransport) InvokeTool(ctx *gin.Context, conn session.Connection, mcpProxyCfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
+func (t *StreamableTransport) InvokeTool(ctx *gin.Context, conn session.Connection, params mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	if !t.IsStarted() {
-		if err := t.Start(ctx.Request.Context(), mcpProxyCfg); err != nil {
+		if err := t.Start(ctx.Request.Context(), nil); err != nil {
 			return nil, err
 		}
 	}
@@ -155,7 +156,7 @@ func (t *StreamableTransport) InvokeTool(ctx *gin.Context, conn session.Connecti
 
 	// Process environment variables with templates
 	renderedClientEnv := make(map[string]string)
-	for k, v := range mcpProxyCfg.Env {
+	for k, v := range t.cfg.Env {
 		rendered, err := template.RenderTemplate(v, tmplCtx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render env template: %w", err)

--- a/internal/core/mcpproxy/transport.go
+++ b/internal/core/mcpproxy/transport.go
@@ -29,6 +29,15 @@ type Transport interface {
 
 	// InvokeTool handles tool invocation
 	InvokeTool(c *gin.Context, conn session.Connection, cfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error)
+
+	// Start starts the transport
+	Start(ctx context.Context, cfg config.MCPServerConfig) error
+
+	// Stop stops the transport
+	Stop(ctx context.Context) error
+
+	// IsStarted returns true if the transport is started
+	IsStarted() bool
 }
 
 // NewTransport creates transport based on the configuration

--- a/internal/core/mcpproxy/transport.go
+++ b/internal/core/mcpproxy/transport.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/mcp/session"
+	"github.com/mcp-ecosystem/mcp-gateway/internal/template"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/mcp"
 )
 
@@ -25,13 +26,13 @@ const (
 // Transport defines the interface for MCP transport implementations
 type Transport interface {
 	// FetchToolList fetches the list of available tools
-	FetchToolList(ctx context.Context, conn session.Connection, cfg config.MCPServerConfig) ([]mcp.ToolSchema, error)
+	FetchToolList(ctx context.Context, conn session.Connection) ([]mcp.ToolSchema, error)
 
 	// InvokeTool handles tool invocation
-	InvokeTool(c *gin.Context, conn session.Connection, cfg config.MCPServerConfig, params mcp.CallToolParams) (*mcp.CallToolResult, error)
+	InvokeTool(c *gin.Context, conn session.Connection, params mcp.CallToolParams) (*mcp.CallToolResult, error)
 
 	// Start starts the transport
-	Start(ctx context.Context, cfg config.MCPServerConfig) error
+	Start(ctx context.Context, tmplCtx *template.Context) error
 
 	// Stop stops the transport
 	Stop(ctx context.Context) error
@@ -44,11 +45,11 @@ type Transport interface {
 func NewTransport(cfg config.MCPServerConfig) (Transport, error) {
 	switch TransportType(cfg.Type) {
 	case TypeSSE:
-		return &SSETransport{}, nil
+		return &SSETransport{cfg: cfg}, nil
 	case TypeStdio:
-		return &StdioTransport{}, nil
+		return &StdioTransport{cfg: cfg}, nil
 	case TypeStreamable:
-		return &StreamableTransport{}, nil
+		return &StreamableTransport{cfg: cfg}, nil
 	default:
 		return nil, fmt.Errorf("unknown transport type: %s", cfg.Type)
 	}

--- a/internal/core/mcpproxy/transport.go
+++ b/internal/core/mcpproxy/transport.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gin-gonic/gin"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
-	"github.com/mcp-ecosystem/mcp-gateway/internal/mcp/session"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/template"
 	"github.com/mcp-ecosystem/mcp-gateway/pkg/mcp"
 )
@@ -25,11 +23,11 @@ const (
 
 // Transport defines the interface for MCP transport implementations
 type Transport interface {
-	// FetchToolList fetches the list of available tools
-	FetchToolList(ctx context.Context, conn session.Connection) ([]mcp.ToolSchema, error)
+	// FetchTools fetches the list of available tools
+	FetchTools(ctx context.Context) ([]mcp.ToolSchema, error)
 
-	// InvokeTool handles tool invocation
-	InvokeTool(c *gin.Context, conn session.Connection, params mcp.CallToolParams) (*mcp.CallToolResult, error)
+	// CallTool invokes a tool
+	CallTool(ctx context.Context, params mcp.CallToolParams, req *template.RequestWrapper) (*mcp.CallToolResult, error)
 
 	// Start starts the transport
 	Start(ctx context.Context, tmplCtx *template.Context) error
@@ -37,8 +35,8 @@ type Transport interface {
 	// Stop stops the transport
 	Stop(ctx context.Context) error
 
-	// IsStarted returns true if the transport is started
-	IsStarted() bool
+	// IsRunning returns true if the transport is running
+	IsRunning() bool
 }
 
 // NewTransport creates transport based on the configuration

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
+	"github.com/mcp-ecosystem/mcp-gateway/internal/template"
 
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/core/mcpproxy"
@@ -313,7 +314,7 @@ func (s *Server) initState(ctx context.Context, cfgs []*config.MCPConfig, oldSta
 						return
 					}
 
-					if err := transport.Start(context.Background(), mcpServer); err != nil {
+					if err := transport.Start(ctx, template.NewContext()); err != nil {
 						s.logger.Error("failed to start server",
 							zap.String("prefix", prefix),
 							zap.String("command", mcpServer.Command),

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -186,7 +186,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 	for prefix, transport := range s.state.prefixToTransport {
-		if transport.IsStarted() {
+		if transport.IsRunning() {
 			wg.Add(1)
 			go func(p string, t mcpproxy.Transport) {
 				defer wg.Done()
@@ -306,7 +306,7 @@ func (s *Server) initState(ctx context.Context, cfgs []*config.MCPConfig, oldSta
 			}
 			if mcpServer.Policy == cnst.PolicyOnStart {
 				go func(prefix string, mcpServer config.MCPServerConfig, transport mcpproxy.Transport) {
-					if transport.IsStarted() {
+					if transport.IsRunning() {
 						s.logger.Info("server already started",
 							zap.String("prefix", prefix),
 							zap.String("command", mcpServer.Command),

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -339,55 +339,37 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 		case cnst.BackendProtoStdio:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn, mcpProxyCfg)
+			tools, err = transport.FetchToolList(c.Request.Context(), conn)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 		case cnst.BackendProtoSSE:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn, mcpProxyCfg)
+			tools, err = transport.FetchToolList(c.Request.Context(), conn)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 		case cnst.BackendProtoStreamable:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn, mcpProxyCfg)
+			tools, err = transport.FetchToolList(c.Request.Context(), conn)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -432,13 +414,6 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 		case cnst.BackendProtoHttp:
 			result = s.invokeHTTPTool(c, req, conn, params)
 		case cnst.BackendProtoStdio:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				errMsg := "Server configuration not found"
-				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				errMsg := "Server configuration not found"
@@ -446,19 +421,12 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, mcpProxyCfg, params)
+			result, err = transport.InvokeTool(c, conn, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
 			}
 		case cnst.BackendProtoSSE:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				errMsg := "Server configuration not found"
-				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				errMsg := "Server configuration not found"
@@ -466,19 +434,12 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, mcpProxyCfg, params)
+			result, err = transport.InvokeTool(c, conn, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
 			}
 		case cnst.BackendProtoStreamable:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				errMsg := "Server configuration not found"
-				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				errMsg := "Server configuration not found"
@@ -486,7 +447,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, mcpProxyCfg, params)
+			result, err = transport.InvokeTool(c, conn, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mcp-ecosystem/mcp-gateway/pkg/version"
+
 	"go.uber.org/zap"
 
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
@@ -309,8 +311,8 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 		result := mcp.InitializedResult{
 			ProtocolVersion: mcp.LatestProtocolVersion,
 			ServerInfo: mcp.ImplementationSchema{
-				Name:    "mcp-gateway",
-				Version: "0.1.0",
+				Name:    cnst.AppName,
+				Version: version.Get(),
 			},
 			Capabilities: mcp.ServerCapabilitiesSchema{
 				Tools: mcp.ToolsCapabilitySchema{
@@ -345,7 +347,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn)
+			tools, err = transport.FetchTools(c.Request.Context())
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -357,7 +359,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn)
+			tools, err = transport.FetchTools(c.Request.Context())
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -369,7 +371,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn)
+			tools, err = transport.FetchTools(c.Request.Context())
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -421,7 +423,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, params)
+			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -434,7 +436,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, params)
+			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -447,7 +449,7 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, params)
+			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return

--- a/internal/core/streamable.go
+++ b/internal/core/streamable.go
@@ -224,55 +224,37 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				tools = []mcp.ToolSchema{}
 			}
 		case cnst.BackendProtoStdio:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn, mcpProxyCfg)
+			tools, err = transport.FetchToolList(c.Request.Context(), conn)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 		case cnst.BackendProtoSSE:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn, mcpProxyCfg)
+			tools, err = transport.FetchToolList(c.Request.Context(), conn)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 		case cnst.BackendProtoStreamable:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn, mcpProxyCfg)
+			tools, err = transport.FetchToolList(c.Request.Context(), conn)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -336,13 +318,6 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 		case cnst.BackendProtoStdio:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				errMsg := "Server configuration not found"
-				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				errMsg := "Server configuration not found"
@@ -350,19 +325,12 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, mcpProxyCfg, params)
+			result, err = transport.InvokeTool(c, conn, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
 			}
 		case cnst.BackendProtoSSE:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				errMsg := "Server configuration not found"
-				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				errMsg := "Server configuration not found"
@@ -370,19 +338,12 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, mcpProxyCfg, params)
+			result, err = transport.InvokeTool(c, conn, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
 			}
 		case cnst.BackendProtoStreamable:
-			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
-			if !ok {
-				errMsg := "Server configuration not found"
-				s.sendProtocolError(c, req.Id, errMsg, http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
-				return
-			}
-
 			transport, ok := s.state.prefixToTransport[conn.Meta().Prefix]
 			if !ok {
 				errMsg := "Server configuration not found"
@@ -390,7 +351,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, mcpProxyCfg, params)
+			result, err = transport.InvokeTool(c, conn, params)
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return

--- a/internal/core/streamable.go
+++ b/internal/core/streamable.go
@@ -197,7 +197,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				},
 			},
 			ServerInfo: mcp.ImplementationSchema{
-				Name:    "mcp-gateway",
+				Name:    cnst.AppName,
 				Version: version.Get(),
 			},
 		}, false)
@@ -230,7 +230,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn)
+			tools, err = transport.FetchTools(c.Request.Context())
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -242,7 +242,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn)
+			tools, err = transport.FetchTools(c.Request.Context())
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -254,7 +254,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = transport.FetchToolList(c.Request.Context(), conn)
+			tools, err = transport.FetchTools(c.Request.Context())
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -325,7 +325,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, params)
+			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -338,7 +338,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, params)
+			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return
@@ -351,7 +351,7 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.InvokeTool(c, conn, params)
+			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return

--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -288,3 +288,58 @@ func (s *Server) invokeHTTPTool(c *gin.Context, req mcp.JSONRPCRequest, conn ses
 
 	return result
 }
+
+// mergeRequestInfo merges request information from both session and HTTP request
+func mergeRequestInfo(meta *session.RequestInfo, req *http.Request) *template.RequestWrapper {
+	wrapper := &template.RequestWrapper{
+		Headers: make(map[string]string),
+		Query:   make(map[string]string),
+		Cookies: make(map[string]string),
+		Path:    make(map[string]string),
+		Body:    make(map[string]any),
+	}
+
+	// Merge headers
+	if meta != nil {
+		for k, v := range meta.Headers {
+			wrapper.Headers[k] = v
+		}
+	}
+	if req != nil {
+		for k, v := range req.Header {
+			if len(v) > 0 {
+				wrapper.Headers[k] = v[0]
+			}
+		}
+	}
+
+	// Merge query parameters
+	if meta != nil {
+		for k, v := range meta.Query {
+			wrapper.Query[k] = v
+		}
+	}
+	if req != nil {
+		for k, v := range req.URL.Query() {
+			if len(v) > 0 {
+				wrapper.Query[k] = v[0]
+			}
+		}
+	}
+
+	// Merge cookies
+	if meta != nil {
+		for k, v := range meta.Cookies {
+			wrapper.Cookies[k] = v
+		}
+	}
+	if req != nil {
+		for _, cookie := range req.Cookies() {
+			if cookie.Name != "" {
+				wrapper.Cookies[cookie.Name] = cookie.Value
+			}
+		}
+	}
+
+	return wrapper
+}

--- a/internal/template/renderer.go
+++ b/internal/template/renderer.go
@@ -73,9 +73,11 @@ func PrepareTemplateContext(requestMeta *session.RequestInfo, args map[string]an
 			tmplCtx.Request.Headers[k] = v
 		}
 	}
-	for k, v := range request.Header {
-		if len(v) > 0 {
-			tmplCtx.Request.Headers[k] = v[0]
+	if request != nil {
+		for k, v := range request.Header {
+			if len(v) > 0 {
+				tmplCtx.Request.Headers[k] = v[0]
+			}
 		}
 	}
 
@@ -85,9 +87,11 @@ func PrepareTemplateContext(requestMeta *session.RequestInfo, args map[string]an
 			tmplCtx.Request.Query[k] = v
 		}
 	}
-	for k, v := range request.URL.Query() {
-		if len(v) > 0 {
-			tmplCtx.Request.Query[k] = v[0]
+	if request != nil {
+		for k, v := range request.URL.Query() {
+			if len(v) > 0 {
+				tmplCtx.Request.Query[k] = v[0]
+			}
 		}
 	}
 
@@ -97,9 +101,11 @@ func PrepareTemplateContext(requestMeta *session.RequestInfo, args map[string]an
 			tmplCtx.Request.Cookies[k] = v
 		}
 	}
-	for _, cookie := range request.Cookies() {
-		if cookie.Name != "" {
-			tmplCtx.Request.Cookies[cookie.Name] = cookie.Value
+	if request != nil {
+		for _, cookie := range request.Cookies() {
+			if cookie.Name != "" {
+				tmplCtx.Request.Cookies[cookie.Name] = cookie.Value
+			}
 		}
 	}
 
@@ -121,6 +127,10 @@ func PrepareTemplateContext(requestMeta *session.RequestInfo, args map[string]an
 
 func preprocessArgs(args map[string]any) map[string]any {
 	processed := make(map[string]any)
+
+	if args == nil {
+		return processed
+	}
 
 	for k, v := range args {
 		switch val := v.(type) {

--- a/internal/template/renderer.go
+++ b/internal/template/renderer.go
@@ -62,67 +62,100 @@ func RenderTemplate(tmpl string, ctx *Context) (string, error) {
 	return renderer.Render(tmpl, ctx)
 }
 
+func AssembleTemplateContext(req *RequestWrapper, args map[string]any, serverCfg map[string]string) (*Context, error) {
+	tmplCtx := NewContext()
+	tmplCtx.Args = preprocessArgs(args)
+
+	if req != nil {
+		tmplCtx.Request = *req
+	}
+
+	if serverCfg != nil {
+		renderedCfg, err := renderServerConfigTemplates(serverCfg, tmplCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render config template: %w", err)
+		}
+		tmplCtx.Config = renderedCfg
+	}
+
+	return tmplCtx, nil
+}
+
 // PrepareTemplateContext prepares the template context with request and config data
 func PrepareTemplateContext(requestMeta *session.RequestInfo, args map[string]any, request *http.Request, serverCfg map[string]string) (*Context, error) {
 	tmplCtx := NewContext()
 	tmplCtx.Args = preprocessArgs(args)
 
-	// Process request headers. We use current request to override the first request.
-	if requestMeta != nil && requestMeta.Headers != nil {
-		for k, v := range requestMeta.Headers {
-			tmplCtx.Request.Headers[k] = v
-		}
-	}
-	if request != nil {
-		for k, v := range request.Header {
-			if len(v) > 0 {
-				tmplCtx.Request.Headers[k] = v[0]
-			}
-		}
-	}
+	mergeHeaders(tmplCtx, requestMeta, request)
+	mergeQuery(tmplCtx, requestMeta, request)
+	mergeCookies(tmplCtx, requestMeta, request)
 
-	// Process request querystring. We use current request to override the first request.
-	if requestMeta != nil && requestMeta.Query != nil {
-		for k, v := range requestMeta.Query {
-			tmplCtx.Request.Query[k] = v
-		}
-	}
-	if request != nil {
-		for k, v := range request.URL.Query() {
-			if len(v) > 0 {
-				tmplCtx.Request.Query[k] = v[0]
-			}
-		}
-	}
-
-	// Process request cookies. We use current request to override the first request.
-	if requestMeta != nil && requestMeta.Cookies != nil {
-		for k, v := range requestMeta.Cookies {
-			tmplCtx.Request.Cookies[k] = v
-		}
-	}
-	if request != nil {
-		for _, cookie := range request.Cookies() {
-			if cookie.Name != "" {
-				tmplCtx.Request.Cookies[cookie.Name] = cookie.Value
-			}
-		}
-	}
-
-	// Only process server config templates if serverCfg is provided
 	if serverCfg != nil {
-		// Process server config templates
-		for k, v := range serverCfg {
-			rendered, err := RenderTemplate(v, tmplCtx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to render config template: %w", err)
-			}
-			serverCfg[k] = rendered
+		renderedCfg, err := renderServerConfigTemplates(serverCfg, tmplCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render config template: %w", err)
 		}
-		tmplCtx.Config = serverCfg
+		tmplCtx.Config = renderedCfg
 	}
 
 	return tmplCtx, nil
+}
+
+func mergeHeaders(ctx *Context, meta *session.RequestInfo, req *http.Request) {
+	if meta != nil {
+		for k, v := range meta.Headers {
+			ctx.Request.Headers[k] = v
+		}
+	}
+	if req != nil {
+		for k, v := range req.Header {
+			if len(v) > 0 {
+				ctx.Request.Headers[k] = v[0]
+			}
+		}
+	}
+}
+
+func mergeQuery(ctx *Context, meta *session.RequestInfo, req *http.Request) {
+	if meta != nil {
+		for k, v := range meta.Query {
+			ctx.Request.Query[k] = v
+		}
+	}
+	if req != nil {
+		for k, v := range req.URL.Query() {
+			if len(v) > 0 {
+				ctx.Request.Query[k] = v[0]
+			}
+		}
+	}
+}
+
+func mergeCookies(ctx *Context, meta *session.RequestInfo, req *http.Request) {
+	if meta != nil {
+		for k, v := range meta.Cookies {
+			ctx.Request.Cookies[k] = v
+		}
+	}
+	if req != nil {
+		for _, cookie := range req.Cookies() {
+			if cookie.Name != "" {
+				ctx.Request.Cookies[cookie.Name] = cookie.Value
+			}
+		}
+	}
+}
+
+func renderServerConfigTemplates(cfg map[string]string, ctx *Context) (map[string]string, error) {
+	rendered := make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		out, err := RenderTemplate(v, ctx)
+		if err != nil {
+			return nil, err
+		}
+		rendered[k] = out
+	}
+	return rendered, nil
 }
 
 func preprocessArgs(args map[string]any) map[string]any {

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -163,7 +163,10 @@
     "env_variables": "Environment Variables",
     "url": "URL",
     "http_method": "HTTP Method",
-    "add_server": "Add Server"
+    "add_server": "Add Server",
+    "startup_policy": "Startup Policy",
+    "policy_on_demand": "Connect on Demand",
+    "policy_on_start": "Connect on Start"
   },
   "chat": {
     "title": "Chat",

--- a/web/src/i18n/locales/zh/translation.json
+++ b/web/src/i18n/locales/zh/translation.json
@@ -240,7 +240,10 @@
     "mcp_servers": "MCP 服务",
     "servers": "服务器",
     "routers": "路由",
-    "tools": "工具"
+    "tools": "工具",
+    "startup_policy": "启动策略",
+    "policy_on_demand": "按需连接",
+    "policy_on_start": "启动时连接"
   },
   "chat": {
     "title": "聊天",

--- a/web/src/pages/gateway/components/MCPServersConfig.tsx
+++ b/web/src/pages/gateway/components/MCPServersConfig.tsx
@@ -205,6 +205,16 @@ export function MCPServersConfig({
             <SelectItem key="streamable-http">streamable-http</SelectItem>
           </Select>
 
+          <Select
+            label={t('gateway.startup_policy')}
+            selectedKeys={[server.policy || "onDemand"]}
+            onChange={(e) => updateServer(index, 'policy', e.target.value)}
+            aria-label={t('gateway.startup_policy')}
+          >
+            <SelectItem key="onDemand">{t('gateway.policy_on_demand')}</SelectItem>
+            <SelectItem key="onStart">{t('gateway.policy_on_start')}</SelectItem>
+          </Select>
+
           {(server.type === 'stdio' || !server.type) && (
             <>
               <Input

--- a/web/src/pages/gateway/types/index.ts
+++ b/web/src/pages/gateway/types/index.ts
@@ -53,6 +53,7 @@ export interface GatewayConfig {
     args?: string[];
     env?: Record<string, string>;
     url?: string;
+    policy?: 'onStart' | 'onDemand';
   }>;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable startup policies for MCP server transports and refactor transport management to support persistent connections with lifecycle control.

New Features:
- Add MCPStartupPolicy (onStart/onDemand) to server config and CLI
- Expose policy selector in web UI and update API types accordingly
- Implement Start, Stop, IsRunning, FetchTools and CallTool methods on transports for persistent connections
- Enable automatic startup of transports for onStart policy and on-demand stopping for onDemand

Enhancements:
- Refactor Transport interface and implementations to reuse clients and avoid reinitialization per request
- Enhance server state management (initState, UpdateConfig, MergeConfig) to handle policies and gracefully shut down unused transports
- Streamline template context assembly with new AssembleTemplateContext and merge helper functions