### PR TITLE
Fix BaseUrl Issue 解决配置baseUrl不生效问题

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/logo.png" />
+    <link rel="icon" type="image/png" href="./logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MCP Gateway</title>
   </head>
@@ -10,6 +10,6 @@
     <div id="root"></div>
     <div id="modal-container"></div>
     <script src="https://cdn.jsdelivr.net/npm/heroui-chat-script@0.0.1/dist/index.min.js"></script>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,7 +38,10 @@ function MainLayout() {
 
 export default function App() {
   return (
-    <Router future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+    <Router 
+      basename={import.meta.env.VITE_BASE_URL}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -24,6 +24,9 @@ import { ChangePasswordDialog } from './ChangePasswordDialog';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { WechatQRCode } from './WechatQRCode';
 
+// 导入logo图片
+import logoImg from '/logo.png';
+
 interface LayoutProps {
   children: React.ReactNode;
 }
@@ -205,10 +208,10 @@ export function Layout({ children }: LayoutProps) {
         >
           <div className="flex items-center justify-center p-4 border-b border-border h-16">
             {isCollapsed ? (
-              <img src="/logo.png" alt="MCP Logo" className="w-8 h-8" />
+              <img src={logoImg} alt="MCP Logo" className="w-8 h-8" />
             ) : (
               <div className="flex items-center gap-2">
-                <img src="/logo.png" alt="MCP Logo" className="w-6 h-6" />
+                <img src={logoImg} alt="MCP Logo" className="w-6 h-6" />
                 <span className="text-xl font-bold">MCP Admin</span>
               </div>
             )}

--- a/web/src/components/WechatQRCode.tsx
+++ b/web/src/components/WechatQRCode.tsx
@@ -9,6 +9,9 @@ import { useTranslation } from 'react-i18next';
 
 import { AccessibleModal } from "./AccessibleModal";
 
+// 导入二维码图片
+import wechatQrcode from '/wechat-qrcode.png';
+
 interface WechatQRCodeProps {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -24,7 +27,7 @@ export function WechatQRCode({ isOpen, onOpenChange }: WechatQRCodeProps) {
         <ModalBody>
           <div className="flex flex-col items-center justify-center">
             <img
-              src="/wechat-qrcode.png"
+              src={wechatQrcode}
               alt="WeChat QR Code"
               className="w-64 h-64 object-contain"
             />


### PR DESCRIPTION
This PR fixes the issue where setting VITE_BASE_URL=/mcp-gateway doesn't take effect properly, causing navigation to redirect to the root path (/) instead.
Internal page navigation errors with the message "The server is configured with a public base URL of /mcp-gateway"
Static resources (such as logo.png, wechat-qrcode.png) using absolute paths result in 404 errors

这个PR解决了在配置VITE_BASE_URL=/mcp-gateway的时候，访问页面没有生效，还是会跳转到根目录/的问题

1. 点击页面内链接时出现路径错误，提示"The server is configured with a public base URL of /mcp-gateway"
2. 静态资源（如logo.png、wechat-qrcode.png）使用绝对路径引用，导致404错误

## 修改内容

### 1. React Router配置

修改App.tsx中的Router组件，添加basename属性，使用环境变量中的VITE_BASE_URL作为基础路径：

```jsx
<Router 
  basename={import.meta.env.VITE_BASE_URL}
  future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
>
```
### 2.静态资源引用路径修复

修改静态资源的引用方式，使用导入方式代替绝对路径
