### PR TITLE
 Fix name and tenant field updates in form mode 修复表单模式下name和tenant字段的更新问题

### DIFF
--- a/web/src/pages/gateway/components/ConfigEditor.tsx
+++ b/web/src/pages/gateway/components/ConfigEditor.tsx
@@ -78,6 +78,7 @@ export function ConfigEditor({ config, onChange, isDark, editorOptions, isEditin
     }
   }, [config]);
 
+
   return (
     <div className="h-full flex flex-col">
       <div className="flex justify-end mb-4">
@@ -120,10 +121,12 @@ export function ConfigEditor({ config, onChange, isDark, editorOptions, isEditin
               label={t('gateway.name')}
               value={generalFormState.name !== undefined ? generalFormState.name : (parsedConfig?.name || "")}
               onChange={(e) => {
+                const newName = e.target.value;
                 setGeneralFormState(prev => ({
                   ...prev,
-                  name: e.target.value
+                  name: newName
                 }));
+                updateConfig({ name: newName });
               }}
               isDisabled={Boolean(isEditing && parsedConfig?.name && parsedConfig.name.trim() !== '')}
               description={(isEditing && parsedConfig?.name && parsedConfig.name.trim() !== '') ? t('gateway.name_locked') : undefined}
@@ -133,10 +136,12 @@ export function ConfigEditor({ config, onChange, isDark, editorOptions, isEditin
               label={t('gateway.tenant')}
               selectedKeys={generalFormState.tenant !== undefined ? [generalFormState.tenant] : (parsedConfig?.tenant ? [parsedConfig.tenant] : ['default'])}
               onChange={(e) => {
+                const newTenant = e.target.value;
                 setGeneralFormState(prev => ({
                   ...prev,
-                  tenant: e.target.value
+                  tenant: newTenant
                 }));
+                updateConfig({ tenant: newTenant });
               }}
               aria-label={t('gateway.tenant')}
               isLoading={isLoadingTenants}


### PR DESCRIPTION
PR: 修复表单模式下name和tenant字段的更新问题
PR: Fix name and tenant field updates in form mode

### 问题描述 / Problem Description
![截屏2025-05-21 16 28 57](https://github.com/user-attachments/assets/1fed470b-14a4-4082-940b-6a198de6792f)
![截屏2025-05-21 16 37 47](https://github.com/user-attachments/assets/1150da49-4f36-47db-9f99-c885954f794c)
在表单模式下，修改网关名称(name)和租户(tenant)字段时，只更新了表单状态，没有更新实际配置，导致创建或编辑保存时这些字段的值未被保存。



In form mode, when modifying the gateway name and tenant fields, only the form state was updated without updating the actual configuration, causing these field values to be lost when creating or editing configurations.
### 改动范围 / Changed Files
web/src/pages/gateway/components/ConfigEditor.tsx
### 修复内容 / Fix Details
1. 在name字段的onChange处理函数中添加配置更新调用
2. 在tenant字段的onChange处理函数中添加配置更新调用
修改前：仅更新表单状态 setGeneralFormState
修改后：同时更新表单状态和配置 setGeneralFormState + updateConfig
1. Added configuration update call in the name field's onChange handler
2. Added configuration update call in the tenant field's onChange handler
Before: Only updated form state with setGeneralFormState
After: Update both form state and configuration with setGeneralFormState + updateConfig

## Summary by Sourcery

Ensure that editing the gateway name and tenant in form mode updates the underlying configuration, not just the form state.

Bug Fixes:
- Add updateConfig call in the name field onChange handler to persist the new name.
- Add updateConfig call in the tenant field onChange handler to persist the new tenant.