### PR TITLE
feat: Add MCP configuration versioning

### DIFF
--- a/internal/common/cnst/action.go
+++ b/internal/common/cnst/action.go
@@ -1,0 +1,15 @@
+package cnst
+
+// ActionType represents the type of action performed on a configuration
+type ActionType string
+
+const (
+	// ActionCreate represents a create action
+	ActionCreate ActionType = "Create"
+	// ActionUpdate represents an update action
+	ActionUpdate ActionType = "Update"
+	// ActionDelete represents a delete action
+	ActionDelete ActionType = "Delete"
+	// ActionRevert represents a revert action
+	ActionRevert ActionType = "Revert"
+)

--- a/internal/common/config/mcp.go
+++ b/internal/common/config/mcp.go
@@ -89,6 +89,21 @@ type (
 		Type string   `json:"type" yaml:"type"`
 		Enum []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 	}
+
+	// MCPConfigVersion represents a version of an MCP configuration
+	MCPConfigVersion struct {
+		Version    int             `json:"version" yaml:"version"`
+		CreatedBy  string          `json:"created_by" yaml:"created_by"`
+		CreatedAt  time.Time       `json:"created_at" yaml:"created_at"`
+		ActionType cnst.ActionType `json:"action_type" yaml:"action_type"` // Create, Update, Delete, Revert
+		Name       string          `json:"name" yaml:"name"`
+		Tenant     string          `json:"tenant" yaml:"tenant"`
+		Routers    string          `json:"routers" yaml:"routers"`
+		Servers    string          `json:"servers" yaml:"servers"`
+		Tools      string          `json:"tools" yaml:"tools"`
+		McpServers string          `json:"mcp_servers" yaml:"mcp_servers"`
+		IsActive   bool            `json:"is_active" yaml:"is_active"` // indicates if this version is currently active
+	}
 )
 
 // ToToolSchema converts a ToolConfig to a ToolSchema
@@ -133,5 +148,15 @@ func (t *ToolConfig) ToToolSchema() mcp.ToolSchema {
 			Properties: properties,
 			Required:   required,
 		},
+	}
+}
+
+// FromMCPConfigVersion creates a new MCPConfigVersion from an MCPConfig
+func FromMCPConfigVersion(cfg *MCPConfig, version int, createdBy string, actionType cnst.ActionType) *MCPConfigVersion {
+	return &MCPConfigVersion{
+		Version:    version,
+		CreatedBy:  createdBy,
+		CreatedAt:  time.Now(),
+		ActionType: actionType,
 	}
 }

--- a/internal/mcp/storage/api.go
+++ b/internal/mcp/storage/api.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// Note: This APIStore is used to fetch MCP configuration from a remote server, it's not a universal use case,
+// if you want to use it, please make sure it's compatible with your server,
+// or you can easily modify it to fit your needs.
+
 // APIStore implements the Store interface using the remote http server
 type APIStore struct {
 	logger *zap.Logger
@@ -52,12 +56,12 @@ func (s *APIStore) Get(_ context.Context, name string) (*config.MCPConfig, error
 	if err != nil {
 		return nil, err
 	}
-	var config config.MCPConfig
-	err = json.Unmarshal([]byte(jsonStr), &config)
+	var data config.MCPConfig
+	err = json.Unmarshal([]byte(jsonStr), &data)
 	if err != nil {
 		return nil, err
 	}
-	return &config, nil
+	return &data, nil
 }
 
 // List implements Store.List
@@ -75,14 +79,36 @@ func (s *APIStore) List(_ context.Context) ([]*config.MCPConfig, error) {
 }
 
 // Update implements Store.Update
-func (s *APIStore) Update(_ context.Context, server *config.MCPConfig) error {
+func (s *APIStore) Update(_ context.Context, _ *config.MCPConfig) error {
 	// only use for read config
 	return nil
 }
 
 // Delete implements Store.Delete
-func (s *APIStore) Delete(_ context.Context, name string) error {
+func (s *APIStore) Delete(_ context.Context, _ string) error {
 	// only use for read config
+	return nil
+}
+
+// GetVersion implements Store.GetVersion
+func (s *APIStore) GetVersion(_ context.Context, _ string, _ int) (*config.MCPConfigVersion, error) {
+	return nil, nil
+}
+
+// ListVersions implements Store.ListVersions
+func (s *APIStore) ListVersions(_ context.Context, _ string) ([]*config.MCPConfigVersion, error) {
+	return nil, nil
+}
+
+// SetActiveVersion implements Store.SetActiveVersion
+func (s *APIStore) SetActiveVersion(_ context.Context, _ string, _ int) error {
+	// API store is read-only
+	return nil
+}
+
+// DeleteVersion implements Store.DeleteVersion
+func (s *APIStore) DeleteVersion(_ context.Context, _ string, _ int) error {
+	// API store is read-only
 	return nil
 }
 

--- a/internal/mcp/storage/db.go
+++ b/internal/mcp/storage/db.go
@@ -2,7 +2,11 @@ package storage
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
+	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
 
 	"github.com/glebarez/sqlite"
@@ -10,6 +14,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // DBStore implements the Store interface using a database
@@ -42,7 +47,7 @@ func NewDBStore(logger *zap.Logger, dbType DatabaseType, dsn string) (*DBStore, 
 	case SQLite:
 		dialector = sqlite.Open(dsn)
 	default:
-		return nil, ErrInvalidDatabaseType
+		return nil, gorm.ErrInvalidDB
 	}
 
 	db, err := gorm.Open(dialector, &gorm.Config{})
@@ -51,7 +56,7 @@ func NewDBStore(logger *zap.Logger, dbType DatabaseType, dsn string) (*DBStore, 
 	}
 
 	// Auto migrate the schema
-	if err := db.AutoMigrate(&MCPConfig{}); err != nil {
+	if err := db.AutoMigrate(&MCPConfig{}, &MCPConfigVersion{}, &ActiveVersion{}); err != nil {
 		return nil, err
 	}
 
@@ -63,25 +68,48 @@ func NewDBStore(logger *zap.Logger, dbType DatabaseType, dsn string) (*DBStore, 
 
 // Create implements Store.Create
 func (s *DBStore) Create(_ context.Context, server *config.MCPConfig) error {
-	model, err := FromMCPConfig(server)
-	if err != nil {
-		return err
-	}
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		model, err := FromMCPConfig(server)
+		if err != nil {
+			return err
+		}
 
-	result := s.db.Create(model)
-	if result.Error != nil {
-		return result.Error
-	}
+		// Create the main record
+		if err := tx.Create(model).Error; err != nil {
+			return err
+		}
 
-	return nil
+		// Create version record
+		version, err := FromMCPConfigVersion(server, 1, "system", cnst.ActionCreate)
+		if err != nil {
+			return err
+		}
+
+		if err := tx.Create(version).Error; err != nil {
+			return err
+		}
+
+		// Create active version record
+		activeVersion := &ActiveVersion{
+			Name:      server.Name,
+			Version:   1,
+			UpdatedAt: time.Now(),
+		}
+
+		if err := tx.Create(activeVersion).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
 // Get implements Store.Get
 func (s *DBStore) Get(_ context.Context, name string) (*config.MCPConfig, error) {
 	var model MCPConfig
-	result := s.db.Where("name = ?", name).First(&model)
-	if result.Error != nil {
-		return nil, result.Error
+	err := s.db.Where("name = ?", name).First(&model).Error
+	if err != nil {
+		return nil, err
 	}
 	return model.ToMCPConfig()
 }
@@ -89,9 +117,9 @@ func (s *DBStore) Get(_ context.Context, name string) (*config.MCPConfig, error)
 // List implements Store.List
 func (s *DBStore) List(_ context.Context) ([]*config.MCPConfig, error) {
 	var models []MCPConfig
-	result := s.db.Find(&models)
-	if result.Error != nil {
-		return nil, result.Error
+	err := s.db.Find(&models).Error
+	if err != nil {
+		return nil, err
 	}
 
 	configs := make([]*config.MCPConfig, len(models))
@@ -106,28 +134,215 @@ func (s *DBStore) List(_ context.Context) ([]*config.MCPConfig, error) {
 }
 
 // Update implements Store.Update
-func (s *DBStore) Update(_ context.Context, server *config.MCPConfig) error {
-	model, err := FromMCPConfig(server)
-	if err != nil {
-		return err
-	}
+func (s *DBStore) Update(ctx context.Context, server *config.MCPConfig) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		model, err := FromMCPConfig(server)
+		if err != nil {
+			return err
+		}
 
-	result := s.db.Save(model)
-	if result.Error != nil {
-		return result.Error
-	}
+		// Update the main record
+		if err := tx.Save(model).Error; err != nil {
+			return err
+		}
 
-	return nil
+		// Get the latest version number
+		var latestVersion int
+		if err := tx.Model(&MCPConfigVersion{}).
+			Where("name = ?", server.Name).
+			Select("COALESCE(MAX(version), 0)").
+			Scan(&latestVersion).Error; err != nil {
+			return err
+		}
+
+		// Create new version
+		version, err := FromMCPConfigVersion(server, latestVersion+1, "system", cnst.ActionUpdate)
+		if err != nil {
+			return err
+		}
+
+		if err := tx.Create(version).Error; err != nil {
+			return err
+		}
+
+		// Update active version
+		activeVersion := &ActiveVersion{
+			Name:      server.Name,
+			Version:   version.Version,
+			UpdatedAt: time.Now(),
+		}
+
+		if err := tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "name"}},
+			DoUpdates: clause.AssignmentColumns([]string{"version", "updated_at"}),
+		}).Create(activeVersion).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
 // Delete implements Store.Delete
-func (s *DBStore) Delete(_ context.Context, name string) error {
-	result := s.db.Where("name = ?", name).Delete(&MCPConfig{})
-	if result.Error != nil {
-		return result.Error
-	}
-	return nil
+func (s *DBStore) Delete(ctx context.Context, name string) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Get the config before deletion to create version record
+		var config MCPConfig
+		if err := tx.Where("name = ?", name).First(&config).Error; err != nil {
+			return err
+		}
+
+		// Get the latest version number
+		var latestVersion int
+		if err := tx.Model(&MCPConfigVersion{}).
+			Where("name = ?", name).
+			Select("COALESCE(MAX(version), 0)").
+			Scan(&latestVersion).Error; err != nil {
+			return err
+		}
+
+		// Create version record for deletion
+		mcpConfig, err := config.ToMCPConfig()
+		if err != nil {
+			return err
+		}
+		version, err := FromMCPConfigVersion(mcpConfig, latestVersion+1, "system", cnst.ActionDelete)
+		if err != nil {
+			return err
+		}
+
+		if err := tx.Create(version).Error; err != nil {
+			return err
+		}
+
+		// Delete the active version
+		if err := tx.Where("name = ?", name).Delete(&ActiveVersion{}).Error; err != nil {
+			return err
+		}
+
+		// Delete the main record
+		if err := tx.Where("name = ?", name).Delete(&MCPConfig{}).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
-// ErrInvalidDatabaseType is returned when an invalid database type is provided
-var ErrInvalidDatabaseType = gorm.ErrInvalidDB
+// GetVersion gets a specific version of the configuration
+func (s *DBStore) GetVersion(ctx context.Context, name string, version int) (*config.MCPConfigVersion, error) {
+	var versionModel MCPConfigVersion
+	if err := s.db.Where("name = ? AND version = ?", name, version).First(&versionModel).Error; err != nil {
+		return nil, err
+	}
+	return &config.MCPConfigVersion{
+		Version:    versionModel.Version,
+		CreatedBy:  versionModel.CreatedBy,
+		CreatedAt:  versionModel.CreatedAt,
+		ActionType: versionModel.ActionType,
+	}, nil
+}
+
+// ListVersions lists all versions of a configuration
+func (s *DBStore) ListVersions(ctx context.Context, name string) ([]*config.MCPConfigVersion, error) {
+	var versions []MCPConfigVersion
+	if err := s.db.Where("name = ?", name).Order("version DESC").Find(&versions).Error; err != nil {
+		return nil, err
+	}
+
+	// Get active version
+	var activeVersion ActiveVersion
+	if err := s.db.Where("name = ?", name).First(&activeVersion).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	result := make([]*config.MCPConfigVersion, len(versions))
+	for i, v := range versions {
+		result[i] = &config.MCPConfigVersion{
+			Version:    v.Version,
+			CreatedBy:  v.CreatedBy,
+			CreatedAt:  v.CreatedAt,
+			ActionType: v.ActionType,
+			Name:       v.Name,
+			Tenant:     v.Tenant,
+			Routers:    v.Routers,
+			Servers:    v.Servers,
+			Tools:      v.Tools,
+			McpServers: v.McpServers,
+			IsActive:   v.Version == activeVersion.Version,
+		}
+	}
+	return result, nil
+}
+
+// DeleteVersion deletes a specific version
+func (s *DBStore) DeleteVersion(ctx context.Context, name string, version int) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Check if this is the active version
+		var activeVersion ActiveVersion
+		if err := tx.Where("name = ? AND version = ?", name, version).First(&activeVersion).Error; err == nil {
+			return fmt.Errorf("cannot delete active version")
+		}
+
+		// Delete the version
+		if err := tx.Where("name = ? AND version = ?", name, version).Delete(&MCPConfigVersion{}).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// SetActiveVersion sets a specific version as the active version
+func (s *DBStore) SetActiveVersion(ctx context.Context, name string, version int) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Check if the version exists
+		var versionModel MCPConfigVersion
+		if err := tx.Where("name = ? AND version = ?", name, version).First(&versionModel).Error; err != nil {
+			return fmt.Errorf("version %d not found: %w", version, err)
+		}
+
+		// Get the latest version number
+		var latestVersion int
+		if err := tx.Model(&MCPConfigVersion{}).
+			Where("name = ?", name).
+			Select("COALESCE(MAX(version), 0)").
+			Scan(&latestVersion).Error; err != nil {
+			return err
+		}
+
+		// Create new version record for revert action
+		newVersion := &MCPConfigVersion{
+			Name:       versionModel.Name,
+			Tenant:     versionModel.Tenant,
+			Version:    latestVersion + 1,
+			ActionType: cnst.ActionRevert,
+			CreatedBy:  "system",
+			CreatedAt:  time.Now(),
+			Routers:    versionModel.Routers,
+			Servers:    versionModel.Servers,
+			Tools:      versionModel.Tools,
+			McpServers: versionModel.McpServers,
+		}
+
+		if err := tx.Create(newVersion).Error; err != nil {
+			return err
+		}
+
+		// Update or create active version
+		activeVersion := &ActiveVersion{
+			Name:      name,
+			Version:   newVersion.Version,
+			UpdatedAt: time.Now(),
+		}
+
+		if err := tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "name"}},
+			DoUpdates: clause.AssignmentColumns([]string{"version", "updated_at"}),
+		}).Create(activeVersion).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/internal/mcp/storage/disk.go
+++ b/internal/mcp/storage/disk.go
@@ -2,19 +2,23 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
 	"gopkg.in/yaml.v3"
 
 	"go.uber.org/zap"
 )
 
-// DiskStore implements the Store interface using the local filesystem
 type DiskStore struct {
 	logger  *zap.Logger
 	baseDir string
@@ -40,7 +44,6 @@ func NewDiskStore(logger *zap.Logger, baseDir string) (*DiskStore, error) {
 	}, nil
 }
 
-// Create implements Store.Create
 func (s *DiskStore) Create(_ context.Context, server *config.MCPConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -63,7 +66,6 @@ func (s *DiskStore) Create(_ context.Context, server *config.MCPConfig) error {
 	return os.WriteFile(path, data, 0644)
 }
 
-// Get implements Store.Get
 func (s *DiskStore) Get(_ context.Context, name string) (*config.MCPConfig, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -82,7 +84,6 @@ func (s *DiskStore) Get(_ context.Context, name string) (*config.MCPConfig, erro
 	return &server, nil
 }
 
-// List implements Store.List
 func (s *DiskStore) List(_ context.Context) ([]*config.MCPConfig, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -123,7 +124,6 @@ func (s *DiskStore) List(_ context.Context) ([]*config.MCPConfig, error) {
 	return servers, nil
 }
 
-// Update implements Store.Update
 func (s *DiskStore) Update(_ context.Context, server *config.MCPConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -138,13 +138,217 @@ func (s *DiskStore) Update(_ context.Context, server *config.MCPConfig) error {
 	return os.WriteFile(path, data, 0644)
 }
 
-// Delete implements Store.Delete
 func (s *DiskStore) Delete(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	path := filepath.Join(s.baseDir, name+".yaml")
 	return os.Remove(path)
+}
+
+func (s *DiskStore) GetVersion(_ context.Context, name string, version int) (*config.MCPConfigVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versionPath := filepath.Join(s.baseDir, "versions", name, fmt.Sprintf("%d.yaml", version))
+	data, err := os.ReadFile(versionPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var model MCPConfigVersion
+	if err := yaml.Unmarshal(data, &model); err != nil {
+		return nil, err
+	}
+
+	return &config.MCPConfigVersion{
+		Version:    model.Version,
+		CreatedBy:  model.CreatedBy,
+		CreatedAt:  model.CreatedAt,
+		ActionType: model.ActionType,
+		Name:       model.Name,
+		Tenant:     model.Tenant,
+		Routers:    model.Routers,
+		Servers:    model.Servers,
+		Tools:      model.Tools,
+		McpServers: model.McpServers,
+	}, nil
+}
+
+func (s *DiskStore) ListVersions(_ context.Context, name string) ([]*config.MCPConfigVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versionsDir := filepath.Join(s.baseDir, "versions", name)
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var versions []*config.MCPConfigVersion
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(versionsDir, entry.Name()))
+		if err != nil {
+			s.logger.Error("failed to read version file",
+				zap.String("file", entry.Name()),
+				zap.Error(err))
+			continue
+		}
+
+		var model MCPConfigVersion
+		if err := yaml.Unmarshal(data, &model); err != nil {
+			s.logger.Error("failed to unmarshal version",
+				zap.String("file", entry.Name()),
+				zap.Error(err))
+			continue
+		}
+
+		versions = append(versions, &config.MCPConfigVersion{
+			Version:    model.Version,
+			CreatedBy:  model.CreatedBy,
+			CreatedAt:  model.CreatedAt,
+			ActionType: model.ActionType,
+			Name:       model.Name,
+			Tenant:     model.Tenant,
+			Routers:    model.Routers,
+			Servers:    model.Servers,
+			Tools:      model.Tools,
+			McpServers: model.McpServers,
+		})
+	}
+
+	// Sort versions by version number in descending order
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Version > versions[j].Version
+	})
+
+	return versions, nil
+}
+
+func (s *DiskStore) DeleteVersion(_ context.Context, name string, version int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	versionPath := filepath.Join(s.baseDir, "versions", name, fmt.Sprintf("%d.yaml", version))
+	return os.Remove(versionPath)
+}
+
+func (s *DiskStore) GetActiveVersion(_ context.Context, name string) (*config.MCPConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	versionsDir := filepath.Join(s.baseDir, "versions", name)
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort entries by version number in descending order
+	sort.Slice(entries, func(i, j int) bool {
+		vi, _ := strconv.Atoi(strings.TrimSuffix(entries[i].Name(), ".yaml"))
+		vj, _ := strconv.Atoi(strings.TrimSuffix(entries[j].Name(), ".yaml"))
+		return vi > vj
+	})
+
+	// Get the latest version
+	if len(entries) > 0 {
+		data, err := os.ReadFile(filepath.Join(versionsDir, entries[0].Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		var model MCPConfigVersion
+		if err := yaml.Unmarshal(data, &model); err != nil {
+			return nil, err
+		}
+
+		return model.ToMCPConfig()
+	}
+
+	return nil, fmt.Errorf("no version found for %s", name)
+}
+
+func (s *DiskStore) SetActiveVersion(_ context.Context, name string, version int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	versionsDir := filepath.Join(s.baseDir, "versions", name)
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		return err
+	}
+
+	// First, deactivate all versions
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(versionsDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		var model MCPConfigVersion
+		if err := yaml.Unmarshal(data, &model); err != nil {
+			continue
+		}
+
+		// Create new version record for revert action
+		cfg, err := model.ToMCPConfig()
+		if err != nil {
+			return err
+		}
+		newVersion, err := FromMCPConfigVersion(cfg, model.Version, "system", cnst.ActionRevert)
+		if err != nil {
+			return err
+		}
+
+		newData, err := yaml.Marshal(newVersion)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(filepath.Join(versionsDir, entry.Name()), newData, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Then, activate the specified version
+	versionPath := filepath.Join(versionsDir, fmt.Sprintf("%d.yaml", version))
+	data, err := os.ReadFile(versionPath)
+	if err != nil {
+		return err
+	}
+
+	var model MCPConfigVersion
+	if err := yaml.Unmarshal(data, &model); err != nil {
+		return err
+	}
+
+	// Create new version record for revert action
+	cfg, err := model.ToMCPConfig()
+	if err != nil {
+		return err
+	}
+	newVersion, err := FromMCPConfigVersion(cfg, model.Version, "system", cnst.ActionRevert)
+	if err != nil {
+		return err
+	}
+
+	newData, err := yaml.Marshal(newVersion)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(versionPath, newData, 0644)
 }
 
 func getConfigPath(baseDir string) string {

--- a/internal/mcp/storage/model.go
+++ b/internal/mcp/storage/model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/mcp-ecosystem/mcp-gateway/internal/common/cnst"
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
 	"gorm.io/gorm"
 )
@@ -103,4 +104,96 @@ func (m *MCPConfig) BeforeCreate(_ *gorm.DB) error {
 func (m *MCPConfig) BeforeUpdate(_ *gorm.DB) error {
 	m.UpdatedAt = time.Now()
 	return nil
+}
+
+// ActiveVersion represents the currently active version of an MCP configuration
+type ActiveVersion struct {
+	ID        uint      `gorm:"primarykey"`
+	Name      string    `gorm:"uniqueIndex;not null"`
+	Version   int       `gorm:"not null"`
+	UpdatedAt time.Time `gorm:"not null"`
+}
+
+// MCPConfigVersion represents the database model for MCPConfigVersion
+type MCPConfigVersion struct {
+	ID         int64           `gorm:"primaryKey;autoIncrement"`
+	Name       string          `gorm:"column:name;index:idx_name_tenant_version,uniqueIndex"`
+	Tenant     string          `gorm:"column:tenant;default:'';index:idx_name_tenant_version,uniqueIndex"`
+	Version    int             `gorm:"column:version;index:idx_name_tenant_version,uniqueIndex"`
+	ActionType cnst.ActionType `gorm:"column:action_type;not null"` // Create, Update, Delete, Revert
+	CreatedBy  string          `gorm:"column:created_by"`
+	CreatedAt  time.Time       `gorm:"column:created_at;default:CURRENT_TIMESTAMP(3)"`
+	Routers    string          `gorm:"type:text;column:routers"`
+	Servers    string          `gorm:"type:text;column:servers"`
+	Tools      string          `gorm:"type:text;column:tools"`
+	McpServers string          `gorm:"type:text;column:mcp_servers"`
+}
+
+// ToMCPConfig converts the database model to MCPConfig
+func (m *MCPConfigVersion) ToMCPConfig() (*config.MCPConfig, error) {
+	cfg := &config.MCPConfig{
+		Name:      m.Name,
+		Tenant:    m.Tenant,
+		CreatedAt: m.CreatedAt,
+		UpdatedAt: m.CreatedAt, // Use CreatedAt as UpdatedAt for versioned configs
+	}
+
+	if len(m.Routers) > 0 {
+		if err := json.Unmarshal([]byte(m.Routers), &cfg.Routers); err != nil {
+			return nil, err
+		}
+	}
+	if len(m.Servers) > 0 {
+		if err := json.Unmarshal([]byte(m.Servers), &cfg.Servers); err != nil {
+			return nil, err
+		}
+	}
+	if len(m.Tools) > 0 {
+		if err := json.Unmarshal([]byte(m.Tools), &cfg.Tools); err != nil {
+			return nil, err
+		}
+	}
+	if len(m.McpServers) > 0 {
+		if err := json.Unmarshal([]byte(m.McpServers), &cfg.McpServers); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg, nil
+}
+
+// FromMCPConfigVersion converts MCPConfig to database model
+func FromMCPConfigVersion(cfg *config.MCPConfig, version int, createdBy string, actionType cnst.ActionType) (*MCPConfigVersion, error) {
+	routers, err := json.Marshal(cfg.Routers)
+	if err != nil {
+		return nil, err
+	}
+
+	servers, err := json.Marshal(cfg.Servers)
+	if err != nil {
+		return nil, err
+	}
+
+	tools, err := json.Marshal(cfg.Tools)
+	if err != nil {
+		return nil, err
+	}
+
+	mcpServers, err := json.Marshal(cfg.McpServers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MCPConfigVersion{
+		Name:       cfg.Name,
+		Tenant:     cfg.Tenant,
+		Version:    version,
+		ActionType: actionType,
+		CreatedBy:  createdBy,
+		CreatedAt:  time.Now(),
+		Routers:    string(routers),
+		Servers:    string(servers),
+		Tools:      string(tools),
+		McpServers: string(mcpServers),
+	}, nil
 }

--- a/internal/mcp/storage/store.go
+++ b/internal/mcp/storage/store.go
@@ -2,23 +2,36 @@ package storage
 
 import (
 	"context"
+
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
 )
 
-// Store defines the interface for MCP server storage operations
+// Store defines the interface for MCP configuration storage
 type Store interface {
-	// Create creates a new MCP server record
+	// Create creates a new MCP configuration
 	Create(ctx context.Context, cfg *config.MCPConfig) error
 
-	// Get retrieves an MCP server record by name
+	// Get gets an MCP configuration by name
 	Get(ctx context.Context, name string) (*config.MCPConfig, error)
 
-	// List retrieves all MCP server records
+	// List lists all MCP configurations
 	List(ctx context.Context) ([]*config.MCPConfig, error)
 
-	// Update updates an existing MCP server record
+	// Update updates an existing MCP configuration
 	Update(ctx context.Context, cfg *config.MCPConfig) error
 
-	// Delete deletes an MCP server record by name
+	// Delete deletes an MCP configuration
 	Delete(ctx context.Context, name string) error
+
+	// GetVersion gets a specific version of the configuration
+	GetVersion(ctx context.Context, name string, version int) (*config.MCPConfigVersion, error)
+
+	// ListVersions lists all versions of a configuration
+	ListVersions(ctx context.Context, name string) ([]*config.MCPConfigVersion, error)
+
+	// DeleteVersion deletes a specific version
+	DeleteVersion(ctx context.Context, name string, version int) error
+
+	// SetActiveVersion sets a specific version as the active version
+	SetActiveVersion(ctx context.Context, name string, version int) error
 }


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive versioning support for MCP configurations across database and disk storage, including new models, interface methods, and action tracking to record create, update, delete, and revert operations.

New Features:
- Introduce version tracking models (MCPConfigVersion, ActiveVersion) and ActionType enum
- Extend Store interface with GetVersion, ListVersions, DeleteVersion, and SetActiveVersion methods
- Implement versioning operations in DBStore with transactional creation, history logging, and active version management
- Implement versioning operations in DiskStore using YAML files under a versions directory
- Stub out versioning methods in APIStore to maintain read-only behavior

Enhancements:
- Wrap DBStore Create, Update, and Delete in transactions and use upsert logic for active version
- Persist configuration versions on disk in timestamped YAML and support sorted listing
- Simplify error handling in DB queries and migration logic

Chores:
- Update APIStore method signatures to accept placeholder parameters and return no-ops for write operations