### PR TITLE
fix: add header args

### DIFF
--- a/pkg/openapi/converter.go
+++ b/pkg/openapi/converter.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/mcp-ecosystem/mcp-gateway/internal/common/config"
+	"github.com/mcp-ecosystem/mcp-gateway/pkg/utils"
 )
 
 // Converter handles the conversion from OpenAPI to MCP configuration
@@ -130,7 +131,7 @@ func (c *Converter) Convert(specData []byte) (*config.MCPConfig, error) {
 
 			tool := config.ToolConfig{
 				Name:         operation.OperationID,
-				Description:  operation.Summary,
+				Description:  utils.FirstNonEmpty(operation.Description, operation.Summary),
 				Method:       method,
 				Endpoint:     fmt.Sprintf("{{.Config.url}}%s", path),
 				Headers:      make(map[string]string),

--- a/pkg/utils/str.go
+++ b/pkg/utils/str.go
@@ -1,0 +1,11 @@
+package utils
+
+func FirstNonEmpty(str1, str2 string) string {
+	if str1 != "" {
+		return str1
+	}
+	if str2 != "" {
+		return str2
+	}
+	return ""
+}


### PR DESCRIPTION
1. add header args
2. use api description as tool description first

## Summary by Sourcery

Implement support for header parameters in the OpenAPI converter and improve tool description selection by preferring the operation description over the summary.

New Features:
- Add support for mapping OpenAPI header parameters into tool arguments

Enhancements:
- Prefer operation.Description over operation.Summary when setting tool descriptions
- Introduce FirstNonEmpty utility function for selecting the first non-empty string