### PR TITLE
fix: Avoid duplicate query parameters in URL when processing arguments

### DIFF
--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -97,6 +97,13 @@ func processArguments(req *http.Request, tool *config.ToolConfig, args map[strin
 			req.Header.Set(arg.Name, value)
 		case "query":
 			q := req.URL.Query()
+			// Check if the parameter already exists in the URL to avoid duplicates
+			// This can happen when the parameter is already included in the endpoint template
+			existingValues := q[arg.Name]
+			if len(existingValues) > 0 {
+				// Remove existing parameter and add the new one to ensure proper encoding
+				q.Del(arg.Name)
+			}
 			q.Add(arg.Name, value)
 			req.URL.RawQuery = q.Encode()
 		case "form-data":


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Delete existing query parameters prior to adding new ones to avoid duplicates in request URLs