### PR TITLE
fix: [mcp-gateway] 修复unla因未按Accept-Encoding解压 HTTP 响应引发的解析乱码问题 #234

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -53,6 +54,7 @@ require (
 	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -112,6 +114,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/core/execute_tool_test.go
+++ b/internal/core/execute_tool_test.go
@@ -1,15 +1,22 @@
 package core
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/andybalholm/brotli"
 	"github.com/amoylab/unla/internal/common/config"
 	"github.com/amoylab/unla/internal/mcp/session"
 	"github.com/amoylab/unla/pkg/mcp"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
@@ -73,4 +80,167 @@ func TestExecuteHTTPTool_ForwardHeadersAndRequestError(t *testing.T) {
 	res, err := s.executeHTTPTool(c, conn, tool, args, map[string]string{})
 	assert.Error(t, err)
 	assert.Nil(t, res)
+}
+
+func TestExecuteHTTPTool_GzipResponse(t *testing.T) {
+	// downstream returns gzip-compressed JSON
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write([]byte(`{"hello":"gzip"}`))
+		_ = gz.Close()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	allowlist, _ := parseInternalNetworkAllowlist([]string{"127.0.0.0/8", "::1/128"})
+	s := &Server{logger: zap.NewNop(), toolRespHandler: CreateResponseHandlerChain(), internalNetACL: allowlist}
+	tool := &config.ToolConfig{
+		Name:         "t",
+		Method:       http.MethodGet,
+		Endpoint:     srv.URL,
+		Headers:      map[string]string{"Accept-Encoding": "gzip"},
+		ResponseBody: "{{.Response.Body}}",
+	}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	conn := &fakeConnExec{meta: &session.Meta{ID: "sid", Request: &session.RequestInfo{Headers: map[string]string{"X-Req": "v"}}}}
+	c, _ := gin.CreateTestContext(nil)
+	c.Request = req
+
+	res, err := s.executeHTTPTool(c, conn, tool, map[string]any{}, map[string]string{})
+	assert.NoError(t, err)
+	if assert.NotNil(t, res) {
+		if tc, ok := res.Content[0].(*mcp.TextContent); ok {
+			assert.Equal(t, `{"hello":"gzip"}`, tc.Text)
+		} else {
+			t.Fatalf("unexpected content type")
+		}
+	}
+}
+
+func TestReadDecodedResponseBody_GzipInvalidData(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{"Content-Encoding": []string{"gzip"}},
+		Body:   io.NopCloser(bytes.NewBufferString("not-gzip-data")),
+	}
+
+	_, err := readDecodedResponseBody(resp)
+	assert.Error(t, err)
+}
+
+func TestExecuteHTTPTool_BrotliResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		br := brotli.NewWriter(&buf)
+		_, _ = br.Write([]byte(`{"hello":"brotli"}`))
+		_ = br.Close()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "br")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	allowlist, _ := parseInternalNetworkAllowlist([]string{"127.0.0.0/8", "::1/128"})
+	s := &Server{logger: zap.NewNop(), toolRespHandler: CreateResponseHandlerChain(), internalNetACL: allowlist}
+	tool := &config.ToolConfig{Name: "t", Method: http.MethodGet, Endpoint: srv.URL, ResponseBody: "{{.Response.Body}}"}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	conn := &fakeConnExec{meta: &session.Meta{ID: "sid", Request: &session.RequestInfo{Headers: map[string]string{}}}}
+	c, _ := gin.CreateTestContext(nil)
+	c.Request = req
+
+	res, err := s.executeHTTPTool(c, conn, tool, map[string]any{}, map[string]string{})
+	assert.NoError(t, err)
+	if assert.NotNil(t, res) {
+		tc, ok := res.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("unexpected content type")
+		}
+		assert.Equal(t, `{"hello":"brotli"}`, tc.Text)
+	}
+}
+
+func TestExecuteHTTPTool_ZstdResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		zw, err := zstd.NewWriter(&buf)
+		assert.NoError(t, err)
+		_, _ = zw.Write([]byte(`{"hello":"zstd"}`))
+		zw.Close()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "zstd")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	allowlist, _ := parseInternalNetworkAllowlist([]string{"127.0.0.0/8", "::1/128"})
+	s := &Server{logger: zap.NewNop(), toolRespHandler: CreateResponseHandlerChain(), internalNetACL: allowlist}
+	tool := &config.ToolConfig{Name: "t", Method: http.MethodGet, Endpoint: srv.URL, ResponseBody: "{{.Response.Body}}"}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	conn := &fakeConnExec{meta: &session.Meta{ID: "sid", Request: &session.RequestInfo{Headers: map[string]string{}}}}
+	c, _ := gin.CreateTestContext(nil)
+	c.Request = req
+
+	res, err := s.executeHTTPTool(c, conn, tool, map[string]any{}, map[string]string{})
+	assert.NoError(t, err)
+	if assert.NotNil(t, res) {
+		tc, ok := res.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("unexpected content type")
+		}
+		assert.Equal(t, `{"hello":"zstd"}`, tc.Text)
+	}
+}
+
+func TestExecuteHTTPTool_DeflateResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		zw := zlib.NewWriter(&buf)
+		_, _ = zw.Write([]byte(`{"hello":"deflate"}`))
+		_ = zw.Close()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "deflate")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	allowlist, _ := parseInternalNetworkAllowlist([]string{"127.0.0.0/8", "::1/128"})
+	s := &Server{logger: zap.NewNop(), toolRespHandler: CreateResponseHandlerChain(), internalNetACL: allowlist}
+	tool := &config.ToolConfig{Name: "t", Method: http.MethodGet, Endpoint: srv.URL, ResponseBody: "{{.Response.Body}}"}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	conn := &fakeConnExec{meta: &session.Meta{ID: "sid", Request: &session.RequestInfo{Headers: map[string]string{}}}}
+	c, _ := gin.CreateTestContext(nil)
+	c.Request = req
+
+	res, err := s.executeHTTPTool(c, conn, tool, map[string]any{}, map[string]string{})
+	assert.NoError(t, err)
+	if assert.NotNil(t, res) {
+		tc, ok := res.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("unexpected content type")
+		}
+		assert.Equal(t, `{"hello":"deflate"}`, tc.Text)
+	}
+}
+
+func TestReadDecodedResponseBody_DeflateRaw(t *testing.T) {
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	assert.NoError(t, err)
+	_, _ = fw.Write([]byte(`{"hello":"raw-deflate"}`))
+	_ = fw.Close()
+
+	resp := &http.Response{
+		Header: http.Header{"Content-Encoding": []string{"deflate"}},
+		Body:   io.NopCloser(bytes.NewReader(buf.Bytes())),
+	}
+
+	body, err := readDecodedResponseBody(resp)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"hello":"raw-deflate"}`, string(body))
 }


### PR DESCRIPTION
## 修复说明
Fixes #234

### 修复逻辑
1. 使用过程中发现mcp-gateway解析有压缩格式的http响应的场景下，会解析乱码，查看源代码发现go这块缺少对压缩格式数据的处理，因此补充了一下对解压响应模块的逻辑，增加了gzip,br,zstd,deflate 4种常见压缩方式的支持

### 测试验证
- 环境：Go 1.24.1  + [Linux](ubuntu:22.04) 
- 验证步骤：增加了6个测试用例
<img width="1338" height="922" alt="image" src="https://github.com/user-attachments/assets/a4a21ab9-6639-4d37-9939-1bfeac856fdd" />

测试用例验证 执行 go test -v ./internal/core/... 已通过测试
<img width="1099" height="868" alt="image" src="https://github.com/user-attachments/assets/3a733b2b-da6c-4087-a62c-f562e488dcab" />

全量测试验证 执行 make test 已通过

流程验证 基于修改后的代码重新打包一个新的mcp-gateway镜像，在对应web ui的页面上的配置有压缩方式的http接口，不需要手动配置“Accept-Encoding: identity” 响应头也可以成功解析有压缩格式的响应
<img width="1688" height="894" alt="image" src="https://github.com/user-attachments/assets/a7814f3b-03f6-49a3-96a9-9a6540329dfe" />

<img width="1422" height="840" alt="image" src="https://github.com/user-attachments/assets/dbf40d4f-1ba0-42d5-9d53-38358132ab75" />

## Summary by Sourcery

Handle HTTP tool responses that use compressed encodings and ensure downstream consumers always see decoded bodies.

Bug Fixes:
- Fix garbled parsing of HTTP responses by decoding bodies according to the Content-Encoding header before further processing.
- Treat invalid gzip payloads as errors instead of returning corrupted data.

Enhancements:
- Support gzip, brotli, zstd, and deflate (including raw deflate streams) when decoding HTTP response bodies for tools.
- Normalize decoded responses by stripping Content-Encoding and Content-Length headers after decompression so downstream handling is consistent.

Build:
- Add brotli and klauspost/compress libraries as indirect dependencies for HTTP response decompression.

Tests:
- Add unit tests covering gzip, brotli, zstd, and deflate HTTP responses and the decoding helper, including raw deflate and invalid gzip scenarios.