### PR TITLE
chore: add ignoreInvalidConfig

### DIFF
--- a/configs/mcp-gateway.yaml
+++ b/configs/mcp-gateway.yaml
@@ -65,6 +65,7 @@ storage:
     url: "${GATEWAY_STORAGE_API_URL:}"
     configJSONPath: "${GATEWAY_STORAGE_API_CONFIG_JSON_PATH:}"
     timeout: "${GATEWAY_STORAGE_API_TIMEOUT:30s}"
+    ignoreInvalidConfig: "${GATEWAY_STORAGE_API_IGNORE_INVALID_CONFIG:false}"
 
 # Notifier configuration
 notifier:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Introduce GATEWAY_STORAGE_API_IGNORE_INVALID_CONFIG environment-driven flag to control ignoring invalid storage API configs in mcp-gateway.yaml.