### PR TITLE
fix: revert redis notifier watch change

### DIFF
--- a/internal/mcp/storage/notifier/redis.go
+++ b/internal/mcp/storage/notifier/redis.go
@@ -64,19 +64,11 @@ func (r *RedisNotifier) Watch(ctx context.Context) (<-chan *config.MCPConfig, er
 
 	ch := make(chan *config.MCPConfig, 10)
 
-	// Capture the current tail before starting the watch loop so callers do not
-	// miss updates published immediately after Watch returns.
-	lastID := "0-0"
-	latest, err := r.client.XRevRangeN(ctx, r.streamName, "+", "-", 1).Result()
-	if err != nil && !errors.Is(err, redis.Nil) {
-		return nil, fmt.Errorf("failed to get stream tail: %w", err)
-	}
-	if len(latest) > 0 {
-		lastID = latest[0].ID
-	}
-
 	go func() {
 		defer close(ch)
+
+		// Start from the latest message ($ means read only new messages)
+		lastID := "$"
 
 		for {
 			select {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the Redis notifier only delivers new messages by starting consumption from the special latest-message ID instead of an explicitly fetched last ID.